### PR TITLE
Add CURLOPT_CAINFO to ssl_curl_problem_solving

### DIFF
--- a/index.php
+++ b/index.php
@@ -57,7 +57,7 @@
         CURLOPT_SSL_CIPHER_LIST  => 'TLSv1',
         
         //uncomment it and download this file http://curl.haxx.se/ca/cacert.pem (its bundle of CA Root Certificates) if you have problems with verifying ssl cert
-        //CURLOPT_CAINFO           => realpath(dirname(__FILE__)) . 'cacert.pem',
+        //CURLOPT_CAINFO           => realpath(dirname(__FILE__)) . '/cacert.pem',
 
         //if you have problems, uncomment these (will make your script vulnerable to MITM attacks):
         //CURLOPT_SSL_VERIFYPEER   => 0,

--- a/index.php
+++ b/index.php
@@ -55,6 +55,9 @@
         //keep this enabled, for more informations check: https://www.openssl.org/~bodo/ssl-poodle.pdf
         CURLOPT_SSLVERSION       => CURL_SSLVERSION_TLSv1,
         CURLOPT_SSL_CIPHER_LIST  => 'TLSv1',
+        
+        //uncomment it and download this file http://curl.haxx.se/ca/cacert.pem (its bundle of CA Root Certificates) if you have problems with verifying ssl cert
+        //CURLOPT_CAINFO           => realpath(dirname(__FILE__)) . 'cacert.pem',
 
         //if you have problems, uncomment these (will make your script vulnerable to MITM attacks):
         //CURLOPT_SSL_VERIFYPEER   => 0,


### PR DESCRIPTION
Some servers fail to give cURL valid CA Root Certs bundle for various reasons - we should add solution to this problem to our "ssl_curl_problem_solving" as it will help people run this code on their servers without problems.
